### PR TITLE
Fix for building with older version of GTK/GDK

### DIFF
--- a/src/library/Yi/UI/Pango/Control.hs
+++ b/src/library/Yi/UI/Pango/Control.hs
@@ -113,7 +113,8 @@ import GI.Gdk
         eventMotionReadY, eventMotionReadX, pattern BUTTON_PRIMARY, EventType,
         colorBlue, colorGreen, colorRed, eventScrollReadDirection,
         eventButtonReadButton, eventButtonReadType, eventButtonReadY,
-        eventButtonReadX, rectangleReadWidth, rectangleReadX, Rectangle)
+        eventButtonReadX)
+import Yi.UI.Pango.Rectangle (rectangleReadWidth, rectangleReadX, Rectangle)
 import GI.Gtk.Enums (PolicyType(..), StateType(..))
 import Data.GI.Base.Signals (SignalHandlerId)
 import GI.Gdk.Flags (EventMask(..))

--- a/src/library/Yi/UI/Pango/Layouts.hs
+++ b/src/library/Yi/UI/Pango/Layouts.hs
@@ -72,10 +72,10 @@ import GI.Gtk.Structs.Requisition
         requisitionReadWidth, Requisition(..))
 import GI.Gdk.Objects.Screen
        (screenGetHeight, screenGetWidth, screenGetDefault)
-import GI.Gdk.Structs.Rectangle
+import Yi.UI.Pango.Rectangle
        (rectangleReadHeight, rectangleReadWidth, rectangleReadY,
         rectangleReadX, rectangleHeight, rectangleWidth, rectangleY,
-        rectangleX, Rectangle(..))
+        rectangleX, Rectangle(..), newRectangle)
 import GI.Gtk.Objects.Paned
        (getPanedPosition, panedPosition, panedPack2, panedPack1, toPaned,
         Paned(..))
@@ -104,8 +104,6 @@ import GI.GObject (Object)
 class WidgetLike w where
   -- | Extracts the main widget. This is the widget to be added to the GUI.
   baseWidget :: w -> IO Widget
-
-newRectangle x y w h = new Rectangle [rectangleX := x, rectangleY := y, rectangleWidth := w, rectangleHeight := h]
 
 ----------------------- The WeightedStack type
 {- | A @WeightedStack@ is like a 'VBox' or 'HBox', except that we may
@@ -208,8 +206,8 @@ relayout o s r = do
     widgetToRectangle (round -> pos, round -> size, widget) =
       (, widget) <$>
         case o of
-          Horizontal -> newRectangle pos y size height
-          Vertical -> newRectangle x pos width size
+          Horizontal -> newRectangle [rectangleX := pos, rectangleY := y, rectangleWidth := size, rectangleHeight := height]
+          Vertical -> newRectangle [rectangleX := x, rectangleY := pos, rectangleWidth := width, rectangleHeight := size]
     startPosition = fromIntegral $
       case o of
         Horizontal -> x

--- a/src/library/Yi/UI/Pango/Rectangle.hs
+++ b/src/library/Yi/UI/Pango/Rectangle.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+-----------------------------------------------------------------------------
+--
+-- Module      :  IDE.Core.ViewFrame
+-- Copyright   :  (c) Juergen Nicklisch-Franken, Hamish Mackenzie
+-- License     :  GNU-GPL
+--
+-- Maintainer  :  <maintainer at leksah.org>
+-- Stability   :  provisional
+-- Portability :  portable
+--
+--
+-- | Portable Rectangle type that works with older Gdk versions
+--
+---------------------------------------------------------------------------------
+
+module Yi.UI.Pango.Rectangle (
+    Rectangle(..)
+,   newRectangle
+,   rectangleWidth
+,   rectangleHeight
+,   rectangleX
+,   rectangleY
+,   rectangleReadWidth
+,   rectangleReadHeight
+,   rectangleReadX
+,   rectangleReadY
+) where
+
+import Data.GI.Base (new, AttrOp)
+import Data.GI.Base.Attributes (AttrOpTag(..))
+#ifdef MIN_VERSION_GDK_3_18
+import GI.Gdk (Rectangle(..), rectangleWidth, rectangleHeight, rectangleX, rectangleY, rectangleReadWidth, rectangleReadHeight, rectangleReadX, rectangleReadY)
+#else
+import Data.Int (Int32)
+import GI.Cairo (RectangleInt(..), rectangleIntWidth, rectangleIntHeight, rectangleIntX, rectangleIntY, rectangleIntReadWidth, rectangleIntReadHeight, rectangleIntReadX, rectangleIntReadY)
+#endif
+
+#ifdef MIN_VERSION_GDK_3_18
+newRectangle :: [AttrOp Rectangle AttrSet] -> IO Rectangle
+newRectangle = new Rectangle
+#else
+type Rectangle      = RectangleInt
+rectangleWidth      = rectangleIntWidth
+rectangleHeight     = rectangleIntHeight
+rectangleX          = rectangleIntX
+rectangleY          = rectangleIntY
+rectangleReadWidth :: Rectangle -> IO Int32
+rectangleReadWidth  = rectangleIntReadWidth
+rectangleReadHeight :: Rectangle -> IO Int32
+rectangleReadHeight = rectangleIntReadHeight
+rectangleReadX :: Rectangle -> IO Int32
+rectangleReadX      = rectangleIntReadX
+rectangleReadY :: Rectangle -> IO Int32
+rectangleReadY      = rectangleIntReadY
+newRectangle :: [AttrOp Rectangle AttrSet] -> IO Rectangle
+newRectangle = new RectangleInt
+#endif

--- a/yi.cabal
+++ b/yi.cabal
@@ -107,6 +107,9 @@ flag hint
   Default: True
   Description: Include hint (haskell interpreter) in yi
 
+flag gdk-318
+  Description: GDK is 3.18 or later
+
 library
   hs-source-dirs: src/library
   default-language: Haskell2010
@@ -119,6 +122,10 @@ library
 
   if flag(hint)
     CPP-options: -DHINT
+
+  if flag(gdk-318)
+    pkgconfig-depends: gdk-3.0 >= 3.18
+    cpp-options: -DMIN_VERSION_GDK_3_18
 
   exposed-modules:
     Yi
@@ -332,6 +339,7 @@ library
     other-modules:
       Yi.UI.Pango.Layouts
       Yi.UI.Pango.Utils
+      Yi.UI.Pango.Rectangle
     build-depends:
       cairo           >= 0.13   && < 0.14,
       haskell-gi-base >= 0.17   && < 0.18,


### PR DESCRIPTION
I tried to build leksah with `-fyi`, but this is what I had to change for it to build. It still produces segfaults though, when I want to use the yi editor. @hamishmack some things I had to change were because of type signature changes in gtk/gdk (no more Maybe, see below), could these be causing the segfaults?
